### PR TITLE
build: fix jest configuration

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -22,11 +22,11 @@
         "winston": "3.8.2"
       },
       "devDependencies": {
-        "@jest/globals": "29.1.2",
         "@swc-node/register": "1.5.2",
         "@swc/core": "1.3.4",
         "@swc/jest": "0.2.23",
         "@tsconfig/node16": "1.0.3",
+        "@types/jest": "29.1.1",
         "@types/node": "18.7.23",
         "@types/supertest": "2.0.12",
         "@typescript-eslint/eslint-plugin": "5.38.1",
@@ -1745,6 +1745,16 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.1.1.tgz",
+      "integrity": "sha512-U9Ey07dGWl6fUFaIaUQUKWG5NoKi/zizeVQCGV8s4nSU0jPgqphVZvS64+8BtWYvrc3ZGw6wo943NSYPxkrp/g==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/json-schema": {
@@ -8330,6 +8340,16 @@
       "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.1.1.tgz",
+      "integrity": "sha512-U9Ey07dGWl6fUFaIaUQUKWG5NoKi/zizeVQCGV8s4nSU0jPgqphVZvS64+8BtWYvrc3ZGw6wo943NSYPxkrp/g==",
+      "dev": true,
+      "requires": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "@types/json-schema": {

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node -r @swc-node/register src/main.ts",
-    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --forceExit",
+    "test": "jest",
     "postinstall": "bower install",
     "format:check": "prettier --check src",
     "format:fix": "prettier --write src",
@@ -25,11 +25,11 @@
     "winston": "3.8.2"
   },
   "devDependencies": {
-    "@jest/globals": "29.1.2",
     "@swc-node/register": "1.5.2",
     "@swc/core": "1.3.4",
     "@swc/jest": "0.2.23",
     "@tsconfig/node16": "1.0.3",
+    "@types/jest": "29.1.1",
     "@types/node": "18.7.23",
     "@types/supertest": "2.0.12",
     "@typescript-eslint/eslint-plugin": "5.38.1",

--- a/server/src/app.spec.ts
+++ b/server/src/app.spec.ts
@@ -1,4 +1,3 @@
-import { beforeEach, describe, it } from '@jest/globals';
 import bodyParser from 'body-parser';
 import express, { Express } from 'express';
 import request from 'supertest';

--- a/server/src/config.spec.ts
+++ b/server/src/config.spec.ts
@@ -1,5 +1,4 @@
-import fs from 'fs';
-import { beforeEach, describe, expect, it } from '@jest/globals';
+import fs from 'node:fs';
 import Configuration from './config';
 
 const TIMEOUT_1000_MILLIS = 1000;

--- a/server/src/repositories/Countries.spec.ts
+++ b/server/src/repositories/Countries.spec.ts
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import _ from 'lodash';
 import Configuration from '../config';
 import Countries from './Countries';

--- a/server/src/repositories/Sellers.spec.ts
+++ b/server/src/repositories/Sellers.spec.ts
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, it } from '@jest/globals';
 import { Seller, buildWithDefaults } from './Seller';
 import Sellers from './Sellers';
 

--- a/server/src/services/OrderService.spec.ts
+++ b/server/src/services/OrderService.spec.ts
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import _ from 'lodash';
 import Configuration from '../config';
 import { Countries } from '../repositories';

--- a/server/src/services/SellerService.spec.ts
+++ b/server/src/services/SellerService.spec.ts
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import UrlAssembler from 'url-assembler';
 import Configuration, { Settings } from '../config';
 import { Seller, Sellers } from '../repositories';
@@ -13,6 +12,8 @@ describe('Seller Service', () => {
   let configurationData: Settings;
 
   beforeEach(() => {
+    jest.spyOn(utils, 'post').mockImplementation(jest.fn());
+
     bob = {
       name: 'bob',
       hostname: 'localhost',
@@ -136,7 +137,6 @@ describe('Seller Service', () => {
   });
 
   it('should send notification to seller', () => {
-    jest.spyOn(utils, 'post').mockImplementation(jest.fn());
     const message = { type: 'INFO' as const, content: 'test' };
 
     sellerService.notify(bob, message);

--- a/server/src/services/dispatcher/BadRequest.spec.ts
+++ b/server/src/services/dispatcher/BadRequest.spec.ts
@@ -1,5 +1,4 @@
 import { IncomingMessage } from 'node:http';
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import Configuration, { BadRequestMode } from '../../config';
 import { Sellers } from '../../repositories';
 import { buildWithDefaults } from '../../repositories/Seller';

--- a/server/src/services/dispatcher/Dispatcher.spec.ts
+++ b/server/src/services/dispatcher/Dispatcher.spec.ts
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import Configuration from '../../config';
 import { Sellers } from '../../repositories';
 import OrderService from '../OrderService';

--- a/server/src/services/dispatcher/SellerCashUpdater.spec.ts
+++ b/server/src/services/dispatcher/SellerCashUpdater.spec.ts
@@ -1,5 +1,4 @@
 import { IncomingMessage } from 'node:http';
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import Configuration from '../../config';
 import { Sellers } from '../../repositories';
 import OrderService from '../OrderService';

--- a/server/src/services/reduction/StandardReduction.spec.ts
+++ b/server/src/services/reduction/StandardReduction.spec.ts
@@ -1,4 +1,3 @@
-import { beforeEach, describe, expect, it } from '@jest/globals';
 import StandardReduction from './StandardReduction';
 
 describe('Standard Reduction', () => {

--- a/server/src/utils.spec.ts
+++ b/server/src/utils.spec.ts
@@ -1,5 +1,4 @@
 import http, { ClientRequest } from 'node:http';
-import { describe, expect, it, jest } from '@jest/globals';
 import utils from './utils';
 
 describe('Utils', () => {


### PR DESCRIPTION
- Remove `--forceExit` from jest configuration and fix open handles
- Do not use `@jest/globals` as it prevents swc/jest from hoisting modules and breaks jest.mock
